### PR TITLE
fix service-rest.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "latest"
 description: Terraria is a 2D sandbox game with gameplay that revolves around exploration, building, combat, and mining.
 name: terraria
-version: 0.4.0
+version: 0.4.1
 icon: https://gamepedia.cursecdn.com/terraria_gamepedia/c/c4/Terraria.png
 maintainers:
   - name: Gavin Mogan

--- a/templates/service-rest.yaml
+++ b/templates/service-rest.yaml
@@ -7,15 +7,17 @@ metadata:
 {{ include "terraria.labels" . | indent 4 }}
   annotations:
     metallb.universe.tf/allow-shared-ip: {{ include "terraria.fullname" . }}
-{{ toYaml .Values.terraria.service.annotations | indent 4 }}
+{{- if .Values.rest.service.annotations }}
+{{ toYaml .Values.rest.service.annotations | indent 4 }}
+{{- end }}
 spec:
-  type: {{ .Values.terraria.service.type }}
-  {{ if .Values.terraria.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.terraria.service.externalTrafficPolicy }}
-  {{ end }}
-  {{ if .Values.terraria.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.terraria.service.loadBalancerIP }}
-  {{ end }}
+  type: {{ .Values.rest.service.type }}
+  {{- if .Values.rest.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.rest.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.rest.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.rest.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: 7878
       targetPort: http


### PR DESCRIPTION
`service-rest.yaml` is not updated and has some lint errors when `rest.enabled` is true.
I fixed it.